### PR TITLE
fix: Add missing field to export in users/export/ids

### DIFF
--- a/src/users/export/types.ts
+++ b/src/users/export/types.ts
@@ -204,6 +204,7 @@ type FieldsToExport =
   | 'devices'
   | 'dob'
   | 'email'
+  | 'email_subscribe'
   | 'external_id'
   | 'first_name'
   | 'gender'


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

This is an undocumented option. I needed to return `email_subscribe` for what I was working on and passed it in and it worked as expected.

## What is the current behavior?

Passing `email_subscribe` to `fields_to_export` will cause a typescript error

## What is the new behavior?

It will allow it

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests

<!--
Any other comments? Thank you for contributing!
-->
