### PR TITLE
feat: add list canvases feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The library supports the following [Braze API endpoints](https://www.braze.com/d
 - [ ] /canvas/data_series
 - [ ] /canvas/data_summary
 - [ ] /canvas/details
-- [ ] /canvas/list
+- [x] /canvas/list
 
 ### Catalogs
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -81,6 +81,13 @@ export class Braze {
   }
 
   canvas = {
+    /**
+     * GET /canvas/list
+     */
+    list: (parameters?: canvas.CanvasListParameters) => {
+      return canvas.list(this.apiUrl, this.apiKey, parameters)
+    },
+
     trigger: {
       schedule: {
         /**

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -1,2 +1,3 @@
+export * from './list'
 export * as trigger from './trigger'
 export * from './types'

--- a/src/canvas/list.test.ts
+++ b/src/canvas/list.test.ts
@@ -1,0 +1,58 @@
+import { Braze } from '../Braze'
+import { get } from '../common/request'
+import type { CanvasListResponse } from './types'
+
+jest.mock('../common/request/get')
+const mockedGet = jest.mocked(get)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('canvas.list()', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+
+  const braze = new Braze(apiUrl, apiKey)
+  const options = {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+  }
+
+  const response: CanvasListResponse = {
+    message: 'success',
+    canvases: [
+      {
+        id: 'canvas_api_identifier',
+        last_edited: '2023-04-20T08:20:00.000Z',
+        name: 'canvas name',
+        tags: ['tag'],
+      },
+    ],
+  }
+
+  it('calls GET /canvas/list with no params', async () => {
+    mockedGet.mockResolvedValueOnce(response)
+    expect(await braze.canvas.list()).toBe(response)
+    expect(mockedGet).toBeCalledWith(`${apiUrl}/canvas/list?`, options)
+    expect(mockedGet).toBeCalledTimes(1)
+  })
+
+  it('calls GET /canvas/list with all params', async () => {
+    mockedGet.mockResolvedValueOnce(response)
+    const params = {
+      page: 100,
+      include_archived: true,
+      sort_direction: 'desc',
+      'last_edit.time[gt]': '2023-04-20T04:20:00',
+    }
+    expect(await braze.canvas.list(params)).toBe(response)
+    expect(mockedGet).toBeCalledWith(
+      `${apiUrl}/canvas/list?page=100&include_archived=true&sort_direction=desc&last_edit.time%5Bgt%5D=2023-04-20T04%3A20%3A00`,
+      options,
+    )
+    expect(mockedGet).toBeCalledTimes(1)
+  })
+})

--- a/src/canvas/list.ts
+++ b/src/canvas/list.ts
@@ -1,0 +1,21 @@
+import { buildOptions, buildParams, get } from '../common/request'
+import type { CanvasListParameters, CanvasListResponse } from './types'
+
+/**
+ * Export canvas list.
+ *
+ * Use this endpoint to export a list of canvases, each of which will include its name, canvas API identifier, whether it is an API canvas, and tags associated with the canvas.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/canvas/get_canvases/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param parameters - Request parameters.
+ * @returns - Braze response.
+ */
+export function list(apiUrl: string, apiKey: string, parameters?: CanvasListParameters) {
+  return get(
+    `${apiUrl}/canvas/list?${buildParams(parameters)}`,
+    buildOptions({ apiKey }),
+  ) as Promise<CanvasListResponse>
+}

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -1,2 +1,30 @@
+import { ServerResponse } from '../common/request'
+
 export * from './trigger/schedule/types'
 export * from './trigger/types'
+
+/**
+ * Request parameters for canvases list.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/canvas/get_canvases/#request-parameters}
+ */
+export interface CanvasListParameters {
+    page?: number
+    include_archived?: boolean
+    sort_direction?: string
+    'last_edit.time[gt]'?: string
+}
+
+/**
+ * Response body for canvases list.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/canvas/get_canvases/#response}
+ */
+export interface CanvasListResponse extends ServerResponse {
+    canvases: {
+        id: string
+        last_edited: string
+        name: string
+        tags: string[]
+    }[]
+}

--- a/src/canvas/types.ts
+++ b/src/canvas/types.ts
@@ -9,10 +9,10 @@ export * from './trigger/types'
  * {@link https://www.braze.com/docs/api/endpoints/export/canvas/get_canvases/#request-parameters}
  */
 export interface CanvasListParameters {
-    page?: number
-    include_archived?: boolean
-    sort_direction?: string
-    'last_edit.time[gt]'?: string
+  page?: number
+  include_archived?: boolean
+  sort_direction?: string
+  'last_edit.time[gt]'?: string
 }
 
 /**
@@ -21,10 +21,10 @@ export interface CanvasListParameters {
  * {@link https://www.braze.com/docs/api/endpoints/export/canvas/get_canvases/#response}
  */
 export interface CanvasListResponse extends ServerResponse {
-    canvases: {
-        id: string
-        last_edited: string
-        name: string
-        tags: string[]
-    }[]
+  canvases: {
+    id: string
+    last_edited: string
+    name: string
+    tags: string[]
+  }[]
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

Add feature:
GET /canvas/list
canvas.list()

## What is the current behavior?

Non-existent

## What is the new behavior?

Lists the canvases - pretty much identical to GET /campaigns/list, except `is_api_campaign` is not on the response

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation

