### PR TITLE
fix(types): make `app_id` optional on `PurchaseObject`

### DIFF
--- a/src/users/types.ts
+++ b/src/users/types.ts
@@ -132,7 +132,7 @@ interface PurchaseObject {
   external_id?: string
   user_alias?: UserAlias
   braze_id?: string
-  app_id: string
+  app_id?: string
   product_id: string
   currency: string
   price: number


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(types): make `app_id` optional on `PurchaseObject`

Fixes #600

https://www.braze.com/docs/api/objects_filters/purchase_object/

## What is the current behavior?

`app_id` is required

## What is the new behavior?

`app_id` is optional

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation