### PR TITLE
feat: add apple and android push object types

### DIFF
--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -27,8 +27,8 @@ export interface MessagesSendObject {
  * {@link https://www.braze.com/docs/api/objects_filters/#messaging-objects}
  */
 export interface MessagesObject {
-  apple_push?: object
-  android_push?: object
+  apple_push?: ApplePushObject
+  android_push?: AndroidPushObject
   windows_phone8_push?: object
   windows_universal_push?: object
   kindle_push?: object
@@ -37,6 +37,131 @@ export interface MessagesObject {
   webhook?: object
   content_card?: object
   sms?: object
+}
+
+/**
+ * Apple push object
+ *
+ * {@link https://www.braze.com/docs/api/objects_filters/messaging/apple_object}
+ */
+export interface ApplePushObject {
+  badge?: number
+  alert?: string | ApplePushAlertObject
+  sound?: string
+  extra?: Record<string, string>
+  'content-available'?: boolean
+  interruption_level?: 'passive' | 'active' | 'time-sensitive' | 'critical'
+  relevance_score?: number
+  expiry?: string
+  custom_uri?: string
+  message_variation_id?: string
+  notification_group_thread_id?: string
+  asset_url?: string
+  asset_file_type?: 'aif' | 'gif' | 'jpg' | 'm4a' | 'mp3' | 'mp4' | 'png' | 'wav'
+  collapse_id?: string
+  mutable_content?: boolean
+  send_to_most_recent_device_only?: boolean
+  category?: string
+  buttons?: ApplePushActionButtonObject[]
+}
+
+/**
+ * Apple push alert object
+ *
+ * {@link https://www.braze.com/docs/api/objects_filters/messaging/apple_object/#apple-push-alert-object}
+ */
+export interface ApplePushAlertObject {
+  body: string
+  title?: string
+  title_loc_key?: string
+  title_loc_args?: string[]
+  action_loc_key?: string
+  loc_key?: string
+  loc_args?: string[]
+  sound?: string
+}
+
+/**
+ * Apple push action button object
+ *
+ * {@link https://www.braze.com/docs/api/objects_filters/messaging/apple_object/#apple-push-action-button-object}
+ */
+export interface ApplePushActionButtonObject {
+  action_id: string
+  action?: 'OPEN_APP' | 'URI' | 'DEEP_LINK' | 'CLOSE'
+  uri?: string
+  use_webview?: boolean
+}
+
+/**
+ * Android push object
+ *
+ * {@link https://www.braze.com/docs/api/objects_filters/messaging/android_object}
+ */
+export interface AndroidPushObject {
+  alert: string
+  title: string
+  extra?: Record<string, string>
+  message_variation_id?: string
+  notification_channel_id?: string
+  priority?: number
+  send_to_sync?: boolean
+  collapse_key?: string
+  sound?: string
+  custom_uri?: string
+  summary_text?: string
+  time_to_live?: number
+  notification_id?: number
+  push_icon_image_url?: string
+  accent_color?: number
+  send_to_most_recent_device_only?: boolean
+  buttons?: AndroidPushActionButtonObject[]
+  conversation_data?: AndroidConversationPushObject
+}
+
+/**
+ * Android push action button object
+ *
+ * {@link https://www.braze.com/docs/api/objects_filters/messaging/android_object/#android-push-action-button-object}
+ */
+export interface AndroidPushActionButtonObject {
+  text: string
+  action?: 'OPEN_APP' | 'URI' | 'DEEP_LINK' | 'CLOSE'
+  uri?: string
+  use_webview?: boolean
+}
+
+/**
+ * Android conversation push object
+ *
+ * {@link https://www.braze.com/docs/api/objects_filters/messaging/android_object/#android-conversation-push-object}
+ */
+export interface AndroidConversationPushObject {
+  shortcut_id: string
+  reply_person_id: string
+  messages: AndroidConversationPushMessageObject[]
+  persons: AndroidConversationPushPersonObject[]
+}
+
+/**
+ * Android conversation push message object
+ *
+ * {@link https://www.braze.com/docs/api/objects_filters/messaging/android_object/#android-conversation-push-message-object}
+ */
+export interface AndroidConversationPushMessageObject {
+  text: string
+  timestamp: number
+  person_id: string
+}
+
+/**
+ * Android conversation push person object
+ *
+ * {@link https://www.braze.com/docs/api/objects_filters/messaging/android_object/#android-conversation-push-person-object}
+ */
+export interface AndroidConversationPushPersonObject {
+  id: string
+  name: string
 }
 
 /**


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

<!-- Is this a feature, bug fix, documentation, etc.? -->

## What is the current behavior?
`apple_push` and `android_push` in the `MessagesObject` are typed as objects. So the user doesn't get type safety or autocomplete features.

<!-- Please link to the issue (if applicable). -->
**Closes #614**

## What is the new behavior?
I've added typings for these objects and any child objects they use based on the following docs:
* [Apple push object](https://www.braze.com/docs/api/objects_filters/messaging/apple_objec)
* [Android push object](https://www.braze.com/docs/api/objects_filters/messaging/android_object/)

<!-- If this is a feature change or bug fix. -->

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation

<!--
Any other comments? Thank you for contributing!
-->