### PR TITLE
feat: add support for content block post methods (create/update)

### DIFF
--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -7,6 +7,7 @@ import type {
   CanvasTriggerScheduleDeleteObject,
   CanvasTriggerScheduleUpdateObject,
   CanvasTriggerSendObject,
+  CreateContentBlockBody,
   EmailBlacklistObject,
   EmailBounceRemoveObject,
   EmailSpamRemoveObject,
@@ -19,6 +20,7 @@ import type {
   SubscriptionStatusSetObject,
   SubscriptionUserStatusObject,
   TransactionalV1CampaignsSendObject,
+  UpdateContentBlockBody,
   UserAliasUpdates,
   UsersAliasObject,
   UsersDeleteObject,
@@ -350,6 +352,20 @@ it('calls users.track() with bulk', async () => {
       'X-Braze-Bulk': 'true',
     },
   })
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls templates.content_blocks.create()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.templates.content_blocks.create(body as CreateContentBlockBody)).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/content_blocks/create`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls templates.content_blocks.update()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.templates.content_blocks.update(body as UpdateContentBlockBody)).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/content_blocks/update`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -284,6 +284,20 @@ export class Braze {
       list: (body: templates.content_blocks.ContentBlockListBody) => {
         return templates.content_blocks.listContentBlocks(this.apiUrl, this.apiKey, body)
       },
+
+      /**
+       * POST /content_blocks/create
+       */
+      create: (body: templates.content_blocks.CreateContentBlockBody) => {
+        return templates.content_blocks.createContentBlock(this.apiUrl, this.apiKey, body)
+      },
+
+      /**
+       * POST /content_blocks/update
+       */
+      update: (body: templates.content_blocks.UpdateContentBlockBody) => {
+        return templates.content_blocks.updateContentBlock(this.apiUrl, this.apiKey, body)
+      },
     },
 
     email_templates: {

--- a/src/templates/content_blocks/create.ts
+++ b/src/templates/content_blocks/create.ts
@@ -1,0 +1,15 @@
+import { buildOptions, post } from '../../common/request'
+import { CreateContentBlockBody, PostContentBlockResponse } from './types'
+
+/**
+ * Create email template.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/post_create_email_content_block/}
+ */
+export function createContentBlock(
+  apiUrl: string,
+  apiKey: string,
+  body: CreateContentBlockBody,
+): Promise<PostContentBlockResponse> {
+  return post(`${apiUrl}/content_blocks/create`, body, buildOptions({ apiKey }))
+}

--- a/src/templates/content_blocks/index.test.ts
+++ b/src/templates/content_blocks/index.test.ts
@@ -1,6 +1,6 @@
 import { Braze } from '../../Braze'
 import { request } from '../../common/request'
-import { ContentBlockListResponse, ContentBlockResponse } from './types'
+import { ContentBlockListResponse, ContentBlockResponse, PostContentBlockResponse } from './types'
 
 jest.mock('../../common/request/request')
 const mockedRequest = jest.mocked(request)
@@ -99,6 +99,55 @@ describe('Content Blocks', () => {
         undefined,
         options,
       )
+      expect(mockedRequest).toBeCalledTimes(1)
+    })
+  })
+
+  describe('templates.content_blocks.create()', () => {
+    const response: PostContentBlockResponse = {
+      content_block_id: '',
+      liquid_tag: '',
+      created_at: '',
+      message: 'success',
+    }
+    const requestBody = {
+      name: '',
+      description: '',
+      content: '',
+    }
+
+    it('calls POST /content_blocks/create with body', async () => {
+      mockedRequest.mockResolvedValueOnce(response)
+      expect(await braze.templates.content_blocks.create(requestBody)).toBe(response)
+      expect(mockedRequest).toBeCalledWith(`${apiUrl}/content_blocks/create`, requestBody, {
+        ...options,
+        method: 'POST',
+      })
+      expect(mockedRequest).toBeCalledTimes(1)
+    })
+  })
+
+  describe('templates.content_blocks.update()', () => {
+    const response: PostContentBlockResponse = {
+      content_block_id: '5',
+      liquid_tag: '',
+      created_at: '',
+      message: 'success',
+    }
+    const requestBody = {
+      name: '',
+      description: '',
+      content: '',
+      content_block_id: '5',
+    }
+
+    it('calls POST /templates/email/update with body', async () => {
+      mockedRequest.mockResolvedValueOnce(response)
+      expect(await braze.templates.content_blocks.update(requestBody)).toBe(response)
+      expect(mockedRequest).toBeCalledWith(`${apiUrl}/content_blocks/update`, requestBody, {
+        ...options,
+        method: 'POST',
+      })
       expect(mockedRequest).toBeCalledTimes(1)
     })
   })

--- a/src/templates/content_blocks/index.ts
+++ b/src/templates/content_blocks/index.ts
@@ -1,3 +1,5 @@
+export * from './create'
 export * from './get'
 export * from './list'
 export * from './types'
+export * from './update'

--- a/src/templates/content_blocks/types.ts
+++ b/src/templates/content_blocks/types.ts
@@ -58,3 +58,38 @@ export interface ContentBlockResponse extends ServerResponse {
   inclusion_count: number
   inclusion_data: string[]
 }
+
+/**
+ * Request body for create content block.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/post_create_email_content_block/}
+ */
+export interface CreateContentBlockBody {
+  name: string
+  description?: string
+  content: string
+  state?: 'active' | 'draft'
+  tags?: string[]
+}
+
+/**
+ * Request body for update content block.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/post_update_content_block/}
+ */
+export interface UpdateContentBlockBody extends Partial<CreateContentBlockBody> {
+  content_block_id: string
+}
+
+/**
+ * Response body for create/update content block.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/post_create_email_content_block/}
+ * {@link https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/post_update_content_block/}
+ */
+export interface PostContentBlockResponse extends ServerResponse {
+  content_block_id: string
+  liquid_tag: string
+  created_at: string
+  message: 'success'
+}

--- a/src/templates/content_blocks/update.ts
+++ b/src/templates/content_blocks/update.ts
@@ -1,0 +1,15 @@
+import { buildOptions, post } from '../../common/request'
+import { PostContentBlockResponse, UpdateContentBlockBody } from './types'
+
+/**
+ * Update content block.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/post_update_content_block/}
+ */
+export function updateContentBlock(
+  apiUrl: string,
+  apiKey: string,
+  body: UpdateContentBlockBody,
+): Promise<PostContentBlockResponse> {
+  return post(`${apiUrl}/content_blocks/update`, body, buildOptions({ apiKey }))
+}


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?
This feature adds support for the create/update Content Block endpoints.

template.content_blocks.create()
POST /content_blocks/create

template.content_blocks.update()
POST /content_blocks/update

## What is the current behavior?
There's no support for Content Block POST method functions.


## What is the new behavior?
Can use the package to create/update Content Blocks.

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation

<!--
Any other comments? Thank you for contributing!
-->
