### PR TITLE
feat: add segments (list/details/analytics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,9 @@ The library supports the following [Braze API endpoints](https://www.braze.com/d
 
 ### Segments
 
-- [ ] /segments/list
-- [ ] /segments/data_series
-- [ ] /segments/details
-- [ ] /sessions/data_series
+- [x] /segments/list
+- [x] /segments/data_series
+- [x] /segments/details
 
 ### Send Messages
 
@@ -219,6 +218,10 @@ The library supports the following [Braze API endpoints](https://www.braze.com/d
 - [x] /transactional/v1/campaigns/{{CAMPAIGN_ID}}/send
 - [x] /campaigns/trigger/send
 - [x] /canvas/trigger/send
+
+### Sessions
+
+- [ ] /sessions/data_series
 
 ### SMS
 

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -206,6 +206,39 @@ it('calls messages.send()', async () => {
   expect(mockedRequest).toBeCalledTimes(1)
 })
 
+it('calls segments.analytics()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.segments.analytics({ segment_id: 'segment_api_identifier', length: 10 })).toBe(
+    response,
+  )
+  expect(mockedRequest).toBeCalledWith(
+    `${apiUrl}/segments/data_series?segment_id=segment_api_identifier&length=10`,
+    undefined,
+    { headers: options.headers },
+  )
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls segments.details()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.segments.details({ segment_id: 'segment_api_identifier' })).toBe(response)
+  expect(mockedRequest).toBeCalledWith(
+    `${apiUrl}/segments/details?segment_id=segment_api_identifier`,
+    undefined,
+    { headers: options.headers },
+  )
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls segments.list()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.segments.list({ page: 100 })).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/segments/list?page=100`, undefined, {
+    headers: options.headers,
+  })
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
 it('calls sends.id.create()', async () => {
   mockedRequest.mockResolvedValueOnce(response)
   expect(await braze.sends.id.create(body as SendsIdCreateObject)).toBe(response)

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -3,6 +3,7 @@ import * as canvas from './canvas'
 import * as catalogs from './catalogs'
 import * as email from './email'
 import * as messages from './messages'
+import * as segments from './segments'
 import * as sends from './sends'
 import * as subscription from './subscription'
 import * as templates from './templates'
@@ -222,6 +223,29 @@ export class Braze {
      */
     send: (body: messages.MessagesSendObject) => {
       return messages.send(this.apiUrl, this.apiKey, body)
+    },
+  }
+
+  segments = {
+    /**
+     * GET /segments/data_series
+     */
+    analytics: (parameters: segments.SegmentsAnalyticsParameters) => {
+      return segments.analytics(this.apiUrl, this.apiKey, parameters)
+    },
+
+    /**
+     * GET /segments/details
+     */
+    details: (parameters: segments.SegmentsDetailsParameters) => {
+      return segments.details(this.apiUrl, this.apiKey, parameters)
+    },
+
+    /**
+     * GET /segments/list
+     */
+    list: (parameters?: segments.SegmentsListParameters) => {
+      return segments.list(this.apiUrl, this.apiKey, parameters)
     },
   }
 

--- a/src/segments/analytics.test.ts
+++ b/src/segments/analytics.test.ts
@@ -1,0 +1,47 @@
+import { Braze } from '../Braze'
+import { get } from '../common/request'
+import type { SegmentsAnalyticsResponse } from './types'
+
+jest.mock('../common/request/get')
+const mockedGet = jest.mocked(get)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('segments.list()', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+
+  const braze = new Braze(apiUrl, apiKey)
+  const options = {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+  }
+
+  const response: SegmentsAnalyticsResponse = {
+    message: 'success',
+    data: [
+      {
+        time: 'segment_api_identifier',
+        size: 1234,
+      },
+    ],
+  }
+
+  it('calls GET /segments/data_series with required param', async () => {
+    mockedGet.mockResolvedValueOnce(response)
+    const params = {
+      segment_id: 'segment_api_identifier',
+      length: 10,
+    }
+    expect(await braze.segments.analytics(params)).toBe(response)
+    expect(mockedGet).toBeCalledWith(
+      `${apiUrl}/segments/data_series?segment_id=segment_api_identifier&length=10`,
+      options,
+    )
+    expect(mockedGet).toBeCalledTimes(1)
+  })
+})

--- a/src/segments/analytics.ts
+++ b/src/segments/analytics.ts
@@ -1,0 +1,21 @@
+import { buildOptions, buildParams, get } from '../common/request'
+import type { SegmentsAnalyticsParameters, SegmentsAnalyticsResponse } from './types'
+
+/**
+ * Get segments analytics.
+ *
+ * Use this endpoint to get analytics on a segment, which includes the size of the segment for each of the requested number of days.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/segments/get_segment_analytics/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param parameters - Request parameters.
+ * @returns - Braze response.
+ */
+export function analytics(apiUrl: string, apiKey: string, parameters: SegmentsAnalyticsParameters) {
+  return get(
+    `${apiUrl}/segments/data_series?${buildParams(parameters)}`,
+    buildOptions({ apiKey }),
+  ) as Promise<SegmentsAnalyticsResponse>
+}

--- a/src/segments/details.test.ts
+++ b/src/segments/details.test.ts
@@ -1,0 +1,47 @@
+import { Braze } from '../Braze'
+import { get } from '../common/request'
+import type { SegmentsDetailsResponse } from './types'
+
+jest.mock('../common/request/get')
+const mockedGet = jest.mocked(get)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('segments.list()', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+
+  const braze = new Braze(apiUrl, apiKey)
+  const options = {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+  }
+
+  const response: SegmentsDetailsResponse = {
+    message: 'success',
+    name: 'segment name',
+    description: 'description',
+    text_description: 'text description',
+    tags: ['tag'],
+    teams: ['team'],
+    created_at: '2024-07-25T13:50:47Z',
+    updated_at: '2024-07-25T13:50:47Z',
+  }
+
+  it('calls GET /segments/details with required param', async () => {
+    mockedGet.mockResolvedValueOnce(response)
+    const params = {
+      segment_id: 'segment_api_identifier',
+    }
+    expect(await braze.segments.details(params)).toBe(response)
+    expect(mockedGet).toBeCalledWith(
+      `${apiUrl}/segments/details?segment_id=segment_api_identifier`,
+      options,
+    )
+    expect(mockedGet).toBeCalledTimes(1)
+  })
+})

--- a/src/segments/details.ts
+++ b/src/segments/details.ts
@@ -1,0 +1,21 @@
+import { buildOptions, buildParams, get } from '../common/request'
+import type { SegmentsDetailsParameters, SegmentsDetailsResponse } from './types'
+
+/**
+ * Get segments list.
+ *
+ * Use this endpoint to get details on a segment, including its name, descriptions, created/updated times, tags and teams.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/segments/get_segment_details/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param parameters - Request parameters.
+ * @returns - Braze response.
+ */
+export function details(apiUrl: string, apiKey: string, parameters: SegmentsDetailsParameters) {
+  return get(
+    `${apiUrl}/segments/details?${buildParams(parameters)}`,
+    buildOptions({ apiKey }),
+  ) as Promise<SegmentsDetailsResponse>
+}

--- a/src/segments/index.ts
+++ b/src/segments/index.ts
@@ -1,0 +1,4 @@
+export * from './analytics'
+export * from './details'
+export * from './list'
+export * from './types'

--- a/src/segments/list.test.ts
+++ b/src/segments/list.test.ts
@@ -1,0 +1,56 @@
+import { Braze } from '../Braze'
+import { get } from '../common/request'
+import type { SegmentsListResponse } from './types'
+
+jest.mock('../common/request/get')
+const mockedGet = jest.mocked(get)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('segments.list()', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+
+  const braze = new Braze(apiUrl, apiKey)
+  const options = {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+  }
+
+  const response: SegmentsListResponse = {
+    message: 'success',
+    segments: [
+      {
+        id: 'segment_api_identifier',
+        name: 'segment name',
+        analytics_tracking_enabled: true,
+        tags: ['tag'],
+      },
+    ],
+  }
+
+  it('calls GET /segments/list with no params', async () => {
+    mockedGet.mockResolvedValueOnce(response)
+    expect(await braze.segments.list()).toBe(response)
+    expect(mockedGet).toBeCalledWith(`${apiUrl}/segments/list?`, options)
+    expect(mockedGet).toBeCalledTimes(1)
+  })
+
+  it('calls GET /segments/list with all params', async () => {
+    mockedGet.mockResolvedValueOnce(response)
+    const params = {
+      page: 100,
+      sort_direction: 'desc',
+    }
+    expect(await braze.segments.list(params)).toBe(response)
+    expect(mockedGet).toBeCalledWith(
+      `${apiUrl}/segments/list?page=100&sort_direction=desc`,
+      options,
+    )
+    expect(mockedGet).toBeCalledTimes(1)
+  })
+})

--- a/src/segments/list.ts
+++ b/src/segments/list.ts
@@ -1,0 +1,21 @@
+import { buildOptions, buildParams, get } from '../common/request'
+import type { SegmentsListParameters, SegmentsListResponse } from './types'
+
+/**
+ * Get segments list.
+ *
+ * Use this endpoint to export a list of segments, each of which will include its name, segment API identifier, whether it has analytics tracking enabled, and tags associated with the segment.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/segments/get_segment/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param parameters - Request parameters.
+ * @returns - Braze response.
+ */
+export function list(apiUrl: string, apiKey: string, parameters?: SegmentsListParameters) {
+  return get(
+    `${apiUrl}/segments/list?${buildParams(parameters)}`,
+    buildOptions({ apiKey }),
+  ) as Promise<SegmentsListResponse>
+}

--- a/src/segments/types.ts
+++ b/src/segments/types.ts
@@ -1,0 +1,73 @@
+import type { ServerResponse } from '../common/request'
+
+/**
+ * Request parameters for segments analytics.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/segments/get_segment_analytics/#request-parameters}
+ */
+export interface SegmentsAnalyticsParameters {
+  segment_id: string
+  length: number
+  ending_at?: string
+}
+
+/**
+ * Response body for segments analytics.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/segments/get_segment_analytics/#response}
+ */
+export interface SegmentsAnalyticsResponse extends ServerResponse {
+  data: {
+    time: string
+    size: number
+  }[]
+}
+
+/**
+ * Request parameters for segments details.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/segments/get_segment_details/#request-parameters}
+ */
+export interface SegmentsDetailsParameters {
+  segment_id: string
+}
+
+/**
+ * Response body for segments details.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/segments/get_segment_details/#response}
+ */
+export interface SegmentsDetailsResponse extends ServerResponse {
+  message: string
+  name?: string
+  description?: string
+  text_description?: string
+  tags?: string[]
+  teams?: string[]
+  created_at?: string
+  updated_at?: string
+}
+
+/**
+ * Request parameters for segments list.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/segments/get_segment/#request-parameters}
+ */
+export interface SegmentsListParameters {
+  page?: number
+  sort_direction?: string
+}
+
+/**
+ * Response body for segments list.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/segments/get_segment/#response}
+ */
+export interface SegmentsListResponse extends ServerResponse {
+  segments: {
+    id: string
+    name: string
+    analytics_tracking_enabled: boolean
+    tags: string[]
+  }[]
+}


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

*Closes https://github.com/braze-community/braze-node/issues/665.*

This feature adds support for Braze's /segments APIs:
- `braze.segments.list()`: GET /segments/list
- `braze.segments.details()`: GET /segments/details
- `braze.segments.analytics()`: GET /segments/data_series

We also fix a minor docs issue where a /sessions endpoint was included in the segments section.

## What is the current behavior?
Not implemented.

## What is the new behavior?
The library can now be used to list and get details/analytics on segments.

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation

<!--
Any other comments? Thank you for contributing!
-->
