### PR TITLE
fix: added missing apns_priority type on messages

### DIFF
--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -105,7 +105,6 @@ export interface AndroidPushObject {
   extra?: Record<string, string>
   message_variation_id?: string
   notification_channel_id?: string
-  android_priority?: string
   priority?: number
   send_to_sync?: boolean
   collapse_key?: string


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

Added added missing `apns_priority` type on messages

according to the docs: https://braze.com/docs/api/objects_filters/messaging/apple_object/#apple-push-object-1

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation

<!--
Any other comments? Thank you for contributing!
-->
