### PR TITLE
feat(send): support email in POST /campaigns/trigger/send

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run lint && npm run lint:tsc && npm run test:ci && npm run test:esm && npm run clean && npm run build",
     "test": "jest",
     "test:ci": "CI=true jest --ci --colors --coverage",
-    "test:esm": "npm run build:esm && node --test src",
+    "test:esm": "npm run build:esm && node --test src/index.test.mjs",
     "test:watch": "jest --watch"
   },
   "repository": {

--- a/src/campaigns/trigger/send.test.ts
+++ b/src/campaigns/trigger/send.test.ts
@@ -16,7 +16,12 @@ describe('/campaigns/trigger/send', () => {
     campaign_id: 'abcdef12-3456-7890-abcd-ef1234567890',
     recipients: [
       {
-        external_user_id: '1234567890',
+        user_alias: {
+          alias_name: 'example_name',
+          alias_label: 'example_label',
+        },
+        external_user_id: 'external_user_identifier',
+        email: 'example@braze.com',
         trigger_properties: {
           example_string_property: 'YOUR_EXAMPLE_STRING',
           example_integer_property: 1234567890,

--- a/src/campaigns/trigger/types.ts
+++ b/src/campaigns/trigger/types.ts
@@ -16,13 +16,18 @@ export interface CampaignsTriggerSendObject {
   trigger_properties?: TriggerProperties
   broadcast?: boolean
   audience?: ConnectedAudienceObject
-  recipients?: (RecipientWithExternalUserId | RecipientWithUserAlias)[]
+  recipients?: (RecipientWithEmail | RecipientWithExternalUserId | RecipientWithUserAlias)[]
+  attachments?: { file_name: string; url: string }[]
 }
 
 interface Recipient {
   trigger_properties?: TriggerProperties
   send_to_existing_only?: boolean
   attributes?: Attributes
+}
+
+interface RecipientWithEmail extends Recipient {
+  email: string
 }
 
 interface RecipientWithExternalUserId extends Recipient {


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(send): support email in POST `/campaigns/trigger/send`

See https://www.braze.com/docs/api/endpoints/messaging/send_messages/post_send_triggered_campaigns/#request-body

> Either "external_user_id" or "user_alias" or "email" is required. Requests must specify only one.

Closes #972

## What is the current behavior?

`email` not supported in recipients TypeScript interface

## What is the new behavior?

`email` is supported in recipients TypeScript interface and `attachments` is also added to the request object interface

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation