### PR TITLE
fix(users): add missing `emails_to_identify` and `phone_numbers_to_identify` fields

### DIFF
--- a/src/users/identify.test.ts
+++ b/src/users/identify.test.ts
@@ -37,4 +37,26 @@ describe('/users/identify', () => {
     })
     expect(mockedPost).toHaveBeenCalledTimes(1)
   })
+
+  it('calls request with url and body when identifying by email', async () => {
+    const emailBody: UsersIdentifyObject = {
+      emails_to_identify: [
+        {
+          external_id: 'external_identifier',
+          email: 'example@example.com',
+          prioritization: ['identified', 'unidentified'],
+        },
+      ],
+    }
+
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await identify(apiUrl, apiKey, emailBody)).toBe(data)
+    expect(mockedPost).toHaveBeenCalledWith(`${apiUrl}/users/identify`, emailBody, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/users/types.ts
+++ b/src/users/types.ts
@@ -1,5 +1,5 @@
 import type { ServerResponse } from '../common/request'
-import type { Properties, UserAlias } from '../common/types'
+import type { Prioritization, Properties, UserAlias } from '../common/types'
 
 export * from './alias/types'
 export * from './export/types'
@@ -16,17 +16,39 @@ export interface UsersTrackObject {
   purchases?: PurchaseObject[]
 }
 
+interface AliasToIdentify {
+  external_id: string
+  user_alias: UserAlias
+}
+
+interface EmailToIdentify {
+  external_id: string
+  email: string
+  prioritization: Prioritization[]
+}
+
+interface PhoneNumberToIdentify {
+  external_id: string
+  phone: string
+  prioritization: Prioritization[]
+}
+
 /**
  * Request body for user identify.
  *
+ * One of `aliases_to_identify`, `emails_to_identify`, or `phone_numbers_to_identify` is required.
+ *
  * {@link https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/#request-body}
  */
-export interface UsersIdentifyObject {
-  aliases_to_identify: {
-    external_id: string
-    user_alias: UserAlias
-  }[]
-}
+export type UsersIdentifyObject = {
+  aliases_to_identify?: AliasToIdentify[]
+  emails_to_identify?: EmailToIdentify[]
+  phone_numbers_to_identify?: PhoneNumberToIdentify[]
+} & (
+  | { aliases_to_identify: AliasToIdentify[] }
+  | { emails_to_identify: EmailToIdentify[] }
+  | { phone_numbers_to_identify: PhoneNumberToIdentify[] }
+)
 
 /**
  * Request body for user merge.


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

The `UsersIdentifyObject` type only supported identifying users by `aliases_to_identify`, but the Braze `/users/identify` endpoint also supports identifying by email or phone number.

## What is the current behavior?

`UsersIdentifyObject` requires `aliases_to_identify` and has no way to identify a user by `emails_to_identify` or `phone_numbers_to_identify`, even though the Braze API supports these.

## What is the new behavior?

Added `emails_to_identify` and `phone_numbers_to_identify` as valid (mutually optional) fields on `UsersIdentifyObject`, alongside `aliases_to_identify`. The type now requires at least one of the three to be present. Added a test covering identify-by-email.

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation

<!--
Any other comments? Thank you for contributing!
-->
