### PR TITLE
refactor: resolve ESLint type-checked errors and fix build config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,10 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci --prefer-offline
+
+      - name: Build package
+        run: npm run build
 
       - name: Lint codebase
         run: npm run lint

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,14 +4,16 @@ on:
     branches:
       - master
 
+permissions: read-all
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     permissions:
       contents: write
       pull-requests: write
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
 
     steps:
       - name: Release Please
@@ -25,7 +27,6 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     permissions:
-      contents: read
       id-token: write
 
     steps:
@@ -39,9 +40,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
-        run: npm ci --prefer-offline
+        run: npm ci --prefer-offline --ignore-scripts
 
       - name: Publish
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -13,10 +13,9 @@ const gitignorePath = fileURLToPath(new URL('.gitignore', import.meta.url))
 export default defineConfig([
   includeIgnoreFile(gitignorePath),
 
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
-
   {
+    files: ['**/*.{cjs,cts,js,jsx,mjs,mts,ts,tsx}'],
+
     plugins: {
       'simple-import-sort': simpleImportSort,
       js,
@@ -24,10 +23,22 @@ export default defineConfig([
       tsdoc,
     },
 
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+      tseslint.configs.recommendedTypeChecked,
+      tseslint.configs.strictTypeChecked,
+      tseslint.configs.stylisticTypeChecked,
+    ],
+
     languageOptions: {
       globals: {
         ...globals.jest,
         ...globals.node,
+      },
+      parserOptions: {
+        project: ['tsconfig.json'],
+        tsconfigRootDir: import.meta.dirname,
       },
     },
 

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -54,15 +54,16 @@ describe('Braze', () => {
 
   it.each([undefined, null, 0, 1, ''])('throws if first argument is %p', (apiUrl) => {
     expect(() => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      // @ts-expect-error Testing invalid argument type
       new Braze(apiUrl)
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     }).toThrow(`Invalid Braze API URL: ${apiUrl}`)
   })
 
   it.each([undefined, null, 0, 1, ''])('throws if second argument is %p', (apiKey) => {
     expect(() => {
       new Braze(apiUrl, apiKey as string)
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     }).toThrow(`Invalid Braze API key: ${apiKey}`)
   })
 })
@@ -74,6 +75,7 @@ const options = {
     Authorization: `Bearer ${apiKey}`,
     'Content-Type': 'application/json',
   },
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   method: expect.stringMatching(/^GET|POST$/),
 }
 const response: ServerResponse = { message: 'success' }

--- a/src/campaigns/details.ts
+++ b/src/campaigns/details.ts
@@ -14,8 +14,8 @@ import type { CampaignsDetailsParameters, CampaignsDetailsResponse } from './typ
  * @returns - Braze response.
  */
 export function details(apiUrl: string, apiKey: string, parameters?: CampaignsDetailsParameters) {
-  return get(
+  return get<CampaignsDetailsResponse>(
     `${apiUrl}/campaigns/details?${buildParams(parameters)}`,
     buildOptions({ apiKey }),
-  ) as Promise<CampaignsDetailsResponse>
+  )
 }

--- a/src/campaigns/list.ts
+++ b/src/campaigns/list.ts
@@ -14,8 +14,8 @@ import type { CampaignsListParameters, CampaignsListResponse } from './types'
  * @returns - Braze response.
  */
 export function list(apiUrl: string, apiKey: string, parameters?: CampaignsListParameters) {
-  return get(
+  return get<CampaignsListResponse>(
     `${apiUrl}/campaigns/list?${buildParams(parameters)}`,
     buildOptions({ apiKey }),
-  ) as Promise<CampaignsListResponse>
+  )
 }

--- a/src/campaigns/trigger/send.ts
+++ b/src/campaigns/trigger/send.ts
@@ -14,8 +14,9 @@ import type { CampaignsTriggerSendObject } from './types'
  * @returns - Braze response.
  */
 export function send(apiUrl: string, apiKey: string, body: CampaignsTriggerSendObject) {
-  return post(`${apiUrl}/campaigns/trigger/send`, body, buildOptions({ apiKey })) as Promise<{
-    dispatch_id: string
-    message: string
-  }>
+  return post<{ dispatch_id: string; message: string }>(
+    `${apiUrl}/campaigns/trigger/send`,
+    body,
+    buildOptions({ apiKey }),
+  )
 }

--- a/src/canvas/list.ts
+++ b/src/canvas/list.ts
@@ -14,8 +14,8 @@ import type { CanvasListParameters, CanvasListResponse } from './types'
  * @returns - Braze response.
  */
 export function list(apiUrl: string, apiKey: string, parameters?: CanvasListParameters) {
-  return get(
+  return get<CanvasListResponse>(
     `${apiUrl}/canvas/list?${buildParams(parameters)}`,
     buildOptions({ apiKey }),
-  ) as Promise<CanvasListResponse>
+  )
 }

--- a/src/canvas/trigger/send.ts
+++ b/src/canvas/trigger/send.ts
@@ -14,8 +14,9 @@ import type { CanvasTriggerSendObject } from './types'
  * @returns - Braze response.
  */
 export function send(apiUrl: string, apiKey: string, body: CanvasTriggerSendObject) {
-  return post(`${apiUrl}/canvas/trigger/send`, body, buildOptions({ apiKey })) as Promise<{
-    dispatch_id: string
-    message: string
-  }>
+  return post<{ dispatch_id: string; message: string }>(
+    `${apiUrl}/canvas/trigger/send`,
+    body,
+    buildOptions({ apiKey }),
+  )
 }

--- a/src/catalogs/synchronous/catalogs.test.ts
+++ b/src/catalogs/synchronous/catalogs.test.ts
@@ -12,6 +12,7 @@ import {
   CatalogListResponse,
 } from './types'
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 jest.mock('../../common/request/request', () => ({
   ...jest.requireActual('../../common/request/request'),
   request: jest.fn(),
@@ -41,6 +42,7 @@ describe('Catalogs - Synchronous', () => {
       catalogs: [],
       message: 'success',
     }
+
     it('is called with no params', async () => {
       mockedRequest.mockResolvedValueOnce(response)
       expect(await braze.catalogs.synchronous.list()).toBe(response)
@@ -92,6 +94,7 @@ describe('Catalogs - Synchronous', () => {
 
     it('is called with required params', async () => {
       fetchMock.getOnce(`${apiUrl}/catalogs/${catalog_name}/items`, response)
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       const itemIterator = await braze.catalogs.synchronous.items<ResponseType>({ catalog_name })
       await expect(itemIterator.next()).resolves.toEqual({ done: false, value: response.items[0] })
       await expect(itemIterator.next()).resolves.toEqual({ done: false, value: response.items[1] })
@@ -107,6 +110,8 @@ describe('Catalogs - Synchronous', () => {
         },
         status: 500,
       })
+
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       const itemIterator = await braze.catalogs.synchronous.items<ResponseType>({ catalog_name })
       await expect(itemIterator.next()).rejects.toThrow(
         new ResponseError('error', 500, ['there was a problem']),
@@ -169,6 +174,7 @@ describe('Catalogs - Synchronous', () => {
           },
         })
 
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       const itemIterator = await braze.catalogs.synchronous.items<ResponseType>({ catalog_name })
       await expect(itemIterator.next()).resolves.toEqual({
         done: false,

--- a/src/catalogs/synchronous/list_items.ts
+++ b/src/catalogs/synchronous/list_items.ts
@@ -1,7 +1,7 @@
 import fetch, { Response } from 'node-fetch'
 
 import { buildOptions, ResponseError } from '../../common/request'
-import { CatalogListItem, CatalogListItemsBody } from './types'
+import { CatalogListItem, CatalogListItemsBody, CatalogListItemsResponse } from './types'
 
 function getNextPageLink(linkHeader: string | null): string | undefined {
   const linkMatches = linkHeader?.matchAll(/<([^>]+)>; rel="(prev|next)"/g)
@@ -39,7 +39,7 @@ class CatalogListItems<T extends CatalogListItem> {
     url: string,
   ): Promise<CatalogListItems<T>> {
     const response: Response = await fetch(apiUrl + url, buildOptions({ apiKey }))
-    const data = await response.json()
+    const data = (await response.json()) as CatalogListItemsResponse<T>
 
     if (!response.ok) {
       throw new ResponseError(data.message, response.status, data.errors)
@@ -78,13 +78,15 @@ export async function* getListCatalogItemsIterator<T extends CatalogListItem>(
   body: CatalogListItemsBody,
 ): AsyncGenerator<T> {
   let result = await getListCatalogItems<T>(apiUrl, apiKey, body)
-  do {
+  let hasNextPage = result.hasNextPage()
+  while (hasNextPage || result.items.length > 0) {
     for (const item of result.items) {
       yield item
     }
-    if (!result.hasNextPage()) {
+    if (!hasNextPage) {
       break
     }
     result = await result.next()
-  } while (true)
+    hasNextPage = result.hasNextPage()
+  }
 }

--- a/src/common/request/params.test.ts
+++ b/src/common/request/params.test.ts
@@ -58,7 +58,13 @@ describe('buildParams', () => {
   })
 
   describe('error', () => {
-    it.each([new Date(), {}, Symbol('symbol'), () => {}])('throws when value is %p', (value) => {
+    it.each([
+      new Date(),
+      {},
+      Symbol('symbol'),
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      () => {},
+    ])('throws when value is %p', (value) => {
       expect(() => buildParams({ value })).toThrow('Unhandled param type for key "value"')
     })
   })

--- a/src/common/request/request.ts
+++ b/src/common/request/request.ts
@@ -47,7 +47,7 @@ export async function request<Response extends ServerResponse>(
     ...options,
   })
 
-  const data: Response = await response.json()
+  const data = (await response.json()) as Response
 
   if (response.ok) {
     return data

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -4,12 +4,12 @@ import assert from 'assert'
 
 import { Braze } from '../esm/index.js'
 
-describe('index', () => {
-  it('exports "Braze" class', () => {
+void describe('index', () => {
+  void it('exports "Braze" class', () => {
     assert.strictEqual(typeof Braze, 'function')
   })
 
-  it('instantiates Braze with API URL and key', () => {
+  void it('instantiates Braze with API URL and key', () => {
     const braze = new Braze('API_URL', 'API_KEY')
     assert.strictEqual(typeof braze.messages.send, 'function')
   })

--- a/src/messages/schedule/create.ts
+++ b/src/messages/schedule/create.ts
@@ -14,9 +14,9 @@ import type { MessagesScheduleCreateObject } from './types'
  * @returns - Braze response.
  */
 export function create(apiUrl: string, apiKey: string, body: MessagesScheduleCreateObject) {
-  return post(`${apiUrl}/messages/schedule/create`, body, buildOptions({ apiKey })) as Promise<{
-    dispatch_id: string
-    schedule_id: string
-    message: 'success' | string
-  }>
+  return post<{ dispatch_id: string; schedule_id: string; message: string }>(
+    `${apiUrl}/messages/schedule/create`,
+    body,
+    buildOptions({ apiKey }),
+  )
 }

--- a/src/messages/send.ts
+++ b/src/messages/send.ts
@@ -14,8 +14,9 @@ import type { MessagesSendObject } from './types'
  * @returns - Braze response.
  */
 export function send(apiUrl: string, apiKey: string, body: MessagesSendObject) {
-  return post(`${apiUrl}/messages/send`, body, buildOptions({ apiKey })) as Promise<{
-    dispatch_id: string
-    message: string
-  }>
+  return post<{ dispatch_id: string; message: string }>(
+    `${apiUrl}/messages/send`,
+    body,
+    buildOptions({ apiKey }),
+  )
 }

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -206,6 +206,7 @@ export interface ScheduledBroadcastsResponse extends ServerResponse {
     type: 'Canvas' | 'Campaign'
     tags: string[]
     next_send_time: string
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
     schedule_type: 'local_time_zones' | 'intelligent_delivery' | string
   }[]
 }

--- a/src/segments/analytics.ts
+++ b/src/segments/analytics.ts
@@ -14,8 +14,8 @@ import type { SegmentsAnalyticsParameters, SegmentsAnalyticsResponse } from './t
  * @returns - Braze response.
  */
 export function analytics(apiUrl: string, apiKey: string, parameters: SegmentsAnalyticsParameters) {
-  return get(
+  return get<SegmentsAnalyticsResponse>(
     `${apiUrl}/segments/data_series?${buildParams(parameters)}`,
     buildOptions({ apiKey }),
-  ) as Promise<SegmentsAnalyticsResponse>
+  )
 }

--- a/src/segments/details.ts
+++ b/src/segments/details.ts
@@ -14,8 +14,8 @@ import type { SegmentsDetailsParameters, SegmentsDetailsResponse } from './types
  * @returns - Braze response.
  */
 export function details(apiUrl: string, apiKey: string, parameters: SegmentsDetailsParameters) {
-  return get(
+  return get<SegmentsDetailsResponse>(
     `${apiUrl}/segments/details?${buildParams(parameters)}`,
     buildOptions({ apiKey }),
-  ) as Promise<SegmentsDetailsResponse>
+  )
 }

--- a/src/segments/list.ts
+++ b/src/segments/list.ts
@@ -14,8 +14,8 @@ import type { SegmentsListParameters, SegmentsListResponse } from './types'
  * @returns - Braze response.
  */
 export function list(apiUrl: string, apiKey: string, parameters?: SegmentsListParameters) {
-  return get(
+  return get<SegmentsListResponse>(
     `${apiUrl}/segments/list?${buildParams(parameters)}`,
     buildOptions({ apiKey }),
-  ) as Promise<SegmentsListResponse>
+  )
 }

--- a/src/sends/id/create.ts
+++ b/src/sends/id/create.ts
@@ -14,8 +14,9 @@ import type { SendsIdCreateObject } from './types'
  * @returns - Braze response.
  */
 export function create(apiUrl: string, apiKey: string, body: SendsIdCreateObject) {
-  return post(`${apiUrl}/sends/id/create`, body, buildOptions({ apiKey })) as Promise<{
-    message: string
-    send_id: string
-  }>
+  return post<{ message: string; send_id: string }>(
+    `${apiUrl}/sends/id/create`,
+    body,
+    buildOptions({ apiKey }),
+  )
 }

--- a/src/subscription/status/get.ts
+++ b/src/subscription/status/get.ts
@@ -14,11 +14,8 @@ import type { SubscriptionStatusGetObject } from './types'
  * @returns - Braze response.
  */
 export function get(apiUrl: string, apiKey: string, body: SubscriptionStatusGetObject) {
-  return _get(
-    `${apiUrl}/subscription/status/get?${buildParams(body)}`,
-    buildOptions({ apiKey }),
-  ) as Promise<{
+  return _get<{
     status: Record<string, 'Subscribed' | 'Unsubscribed' | 'Unknown'>
-    message: 'success' | string
-  }>
+    message: string
+  }>(`${apiUrl}/subscription/status/get?${buildParams(body)}`, buildOptions({ apiKey }))
 }

--- a/src/subscription/status/set.ts
+++ b/src/subscription/status/set.ts
@@ -14,7 +14,9 @@ import type { SubscriptionStatusSetObject } from './types'
  * @returns - Braze response.
  */
 export function set(apiUrl: string, apiKey: string, body: SubscriptionStatusSetObject) {
-  return post(`${apiUrl}/subscription/status/set`, body, buildOptions({ apiKey })) as Promise<{
-    message: 'success' | string
-  }>
+  return post<{ message: string }>(
+    `${apiUrl}/subscription/status/set`,
+    body,
+    buildOptions({ apiKey }),
+  )
 }

--- a/src/subscription/user/types.ts
+++ b/src/subscription/user/types.ts
@@ -12,17 +12,17 @@ export interface SubscriptionUserStatusObject {
 }
 
 export interface SubscriptionUserStatusResponse {
-  users: Array<{
+  users: {
     email: string | null
     phone: string | null
     external_id: string | null
-    subscription_groups: Array<{
+    subscription_groups: {
       id: string
       name: string
       channel: string
       status: 'Subscribed' | 'Unsubscribed'
-    }>
-  }>
+    }[]
+  }[]
   total_count: number
   message: string
   errors?: string[]

--- a/src/users/export/global_control_group.ts
+++ b/src/users/export/global_control_group.ts
@@ -21,9 +21,9 @@ export function global_control_group(
   apiKey: string,
   body: UsersExportGlobalControlGroupObject,
 ) {
-  return post(
+  return post<UsersExportGlobalControlGroupResponse>(
     `${apiUrl}/users/export/global_control_group`,
     body,
     buildOptions({ apiKey }),
-  ) as Promise<UsersExportGlobalControlGroupResponse>
+  )
 }

--- a/src/users/export/ids.ts
+++ b/src/users/export/ids.ts
@@ -14,9 +14,5 @@ import type { UsersExportIdsObject, UsersExportIdsResponse } from './types'
  * @returns - Braze response.
  */
 export function ids(apiUrl: string, apiKey: string, body: UsersExportIdsObject) {
-  return post(
-    `${apiUrl}/users/export/ids`,
-    body,
-    buildOptions({ apiKey }),
-  ) as Promise<UsersExportIdsResponse>
+  return post<UsersExportIdsResponse>(`${apiUrl}/users/export/ids`, body, buildOptions({ apiKey }))
 }

--- a/src/users/export/segment.ts
+++ b/src/users/export/segment.ts
@@ -14,9 +14,9 @@ import type { UsersExportSegmentObject, UsersExportSegmentResponse } from './typ
  * @returns - Braze response.
  */
 export function segment(apiUrl: string, apiKey: string, body: UsersExportSegmentObject) {
-  return post(
+  return post<UsersExportSegmentResponse>(
     `${apiUrl}/users/export/segment`,
     body,
     buildOptions({ apiKey }),
-  ) as Promise<UsersExportSegmentResponse>
+  )
 }

--- a/src/users/export/types.ts
+++ b/src/users/export/types.ts
@@ -17,6 +17,7 @@ export interface UsersExportGlobalControlGroupObject {
  * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_global_control_group/#response}
  */
 export interface UsersExportGlobalControlGroupResponse {
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   message: 'success' | string
   object_prefix: string
   url?: string
@@ -43,6 +44,7 @@ export interface UsersExportIdsObject {
  * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_identifier/#response}
  */
 export interface UsersExportIdsResponse {
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   message: 'success' | string
   users: Partial<UserExportObject>[]
   invalid_user_ids?: string[]
@@ -66,6 +68,7 @@ export interface UsersExportSegmentObject {
  * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment/#response}
  */
 export interface UsersExportSegmentResponse {
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   message: 'success' | string
   object_prefix: string
   url?: string

--- a/src/users/external_ids/remove.ts
+++ b/src/users/external_ids/remove.ts
@@ -16,9 +16,9 @@ import type { UsersExternalIdsRemoveObject } from './types'
  * @returns - Braze response.
  */
 export function remove(apiUrl: string, apiKey: string, body: UsersExternalIdsRemoveObject) {
-  return post(`${apiUrl}/users/external_ids/remove`, body, buildOptions({ apiKey })) as Promise<{
-    message: string
-    removed_ids: string[]
-    removal_errors: string[]
-  }>
+  return post<{ message: string; removed_ids: string[]; removal_errors: string[] }>(
+    `${apiUrl}/users/external_ids/remove`,
+    body,
+    buildOptions({ apiKey }),
+  )
 }

--- a/src/users/external_ids/rename.ts
+++ b/src/users/external_ids/rename.ts
@@ -14,9 +14,9 @@ import type { UsersExternalIdsRenameObject } from './types'
  * @returns - Braze response.
  */
 export function rename(apiUrl: string, apiKey: string, body: UsersExternalIdsRenameObject) {
-  return post(`${apiUrl}/users/external_ids/rename`, body, buildOptions({ apiKey })) as Promise<{
-    message: string
-    external_ids: string[]
-    rename_errors: string[]
-  }>
+  return post<{ message: string; external_ids: string[]; rename_errors: string[] }>(
+    `${apiUrl}/users/external_ids/rename`,
+    body,
+    buildOptions({ apiKey }),
+  )
 }

--- a/src/v2/subscription/status/set.ts
+++ b/src/v2/subscription/status/set.ts
@@ -14,7 +14,9 @@ import type { V2SubscriptionStatusSetObject } from './types'
  * @returns - Braze response.
  */
 export function set(apiUrl: string, apiKey: string, body: V2SubscriptionStatusSetObject) {
-  return post(`${apiUrl}/v2/subscription/status/set`, body, buildOptions({ apiKey })) as Promise<{
-    message: 'success' | string
-  }>
+  return post<{ message: string }>(
+    `${apiUrl}/v2/subscription/status/set`,
+    body,
+    buildOptions({ apiKey }),
+  )
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,8 +1,12 @@
 {
   "extends": ".",
   "compilerOptions": {
-    "lib": ["es2020"],
-    "rootDir": "src"
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.build.tsbuildinfo",
+    "target": "es2020",
+    "rootDir": "src",
+    "outDir": "cjs",
+    "noEmit": false
   },
+  "include": ["src"],
   "exclude": ["node_modules", "**/*.test.*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,19 @@
 {
   "compilerOptions": {
-    "target": "es2020",
-    "module": "commonjs",
-    "lib": ["es2020", "dom"],
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
+    "target": "esnext",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["es2020"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "types": ["node", "jest"],
-    "outDir": "cjs"
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowJs": true
   },
-  "include": ["src"]
+  "include": ["src", "*.mjs", "*.mts", "*.ts"]
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

Refactor to fix ESLint type-checked lint errors introduced by stricter type-checked rules in the modernized ESLint config, and fix the build config for TypeScript 6.

## What is the current behavior?

- ESLint type-checked rules (strictTypeChecked, stylisticTypeChecked) produce errors for unsafe assignments, floating promises, redundant type constituents, etc.
- `tsconfig.build.json` fails with TS6059 errors because root-level files (`eslint.config.mts`, `jest.config.ts`) are included via the base tsconfig but outside `rootDir`
- `as Promise<T>` assertions on `get`/`post` return types trigger `no-unnecessary-type-assertion`

## What is the new behavior?

- Replace `as Promise<T>` assertions with explicit generic type arguments on `get`/`post` (e.g. `get<CampaignsDetailsResponse>(...)`) to preserve response types without triggering lint errors
- Add inline `eslint-disable-next-line` comments for test-specific false positives (`await-thenable`, `no-empty-function`, `no-unsafe-*`, `restrict-template-expressions`)
- Replace `@ts-ignore` with `@ts-expect-error` in `Braze.test.ts`
- Restore literal union types (`'local_time_zones' | 'intelligent_delivery' | string`, `'success' | string`) with eslint-disable comments for documentation value
- Type `response.json()` calls to fix `unsafe-assignment` errors
- Restructure `do...while(true)` loop to avoid `no-unnecessary-condition`
- Add `allowJs` to `tsconfig.json` for `.mjs` files in TS project
- Fix `tsconfig.build.json`: override `include` to `["src"]`, add `noEmit: false`
- Add `void` operator to `node:test` calls for `no-floating-promises`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation